### PR TITLE
Wait for backend in the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Start dockers
         run: docker-compose up -d
       - name: Test backend running
-        run: curl localhost:5000
+        run: timeout 300s bash -c "while !(curl localhost:5000); do sleep 1; done"
       - name: Test DB running
         env: 
           DOCKER_CONTAINER_NAME: "postgres-deadflowers"


### PR DESCRIPTION
Fix non-deterministic CI runs (as seen [here](https://github.com/Dead-Flowers/PZSP2/runs/4369348109)).